### PR TITLE
Add API persistence for diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ VITE_OPENAI_API_ENDPOINT=http://localhost:8000/v1
 VITE_LLM_MODEL_NAME=Qwen/Qwen2.5-32B-Instruct-AWQ
 ```
 
+### Remote diagram storage
+
+To store diagrams on a backend service set the `VITE_API_BASE_URL` environment
+variable. When defined ChartDB uses `PUT` and `GET` requests to
+`${VITE_API_BASE_URL}/diagrams/:id` to persist ER diagrams.
+
 ## Try it on our website
 
 1. Go to [ChartDB.io](https://chartdb.io?ref=github_readme_2)

--- a/src/context/storage-context/storage-context.tsx
+++ b/src/context/storage-context/storage-context.tsx
@@ -38,6 +38,10 @@ export interface StorageContext {
     }) => Promise<void>;
     deleteDiagram: (id: string) => Promise<void>;
 
+    // Remote persistence
+    saveDiagramToApi: (diagram: Diagram) => Promise<void>;
+    getDiagramFromApi: (id: string) => Promise<Diagram | undefined>;
+
     // Table operations
     addTable: (params: { diagramId: string; table: DBTable }) => Promise<void>;
     getTable: (params: {
@@ -137,6 +141,8 @@ export const storageInitialValue: StorageContext = {
     getDiagram: emptyFn,
     updateDiagram: emptyFn,
     deleteDiagram: emptyFn,
+    saveDiagramToApi: emptyFn,
+    getDiagramFromApi: emptyFn,
 
     addTable: emptyFn,
     getTable: emptyFn,

--- a/src/context/storage-context/storage-provider.tsx
+++ b/src/context/storage-context/storage-provider.tsx
@@ -10,6 +10,7 @@ import type { ChartDBConfig } from '@/lib/domain/config';
 import type { DBDependency } from '@/lib/domain/db-dependency';
 import type { Area } from '@/lib/domain/area';
 import type { DBCustomType } from '@/lib/domain/db-custom-type';
+import { saveDiagram, getDiagram } from '@/lib/api/diagram-api';
 
 export const StorageProvider: React.FC<React.PropsWithChildren> = ({
     children,
@@ -715,6 +716,20 @@ export const StorageProvider: React.FC<React.PropsWithChildren> = ({
         [db]
     );
 
+    const saveDiagramToApi: StorageContext['saveDiagramToApi'] = useCallback(
+        async (diagram) => {
+            await saveDiagram(diagram);
+        },
+        []
+    );
+
+    const getDiagramFromApi: StorageContext['getDiagramFromApi'] = useCallback(
+        async (id) => {
+            return await getDiagram(id);
+        },
+        []
+    );
+
     return (
         <storageContext.Provider
             value={{
@@ -725,6 +740,8 @@ export const StorageProvider: React.FC<React.PropsWithChildren> = ({
                 getDiagram,
                 updateDiagram,
                 deleteDiagram,
+                saveDiagramToApi,
+                getDiagramFromApi,
                 addTable,
                 getTable,
                 updateTable,

--- a/src/lib/api/diagram-api.ts
+++ b/src/lib/api/diagram-api.ts
@@ -1,0 +1,52 @@
+import { Diagram, diagramSchema } from '@/lib/domain/diagram';
+import { API_BASE_URL } from '@/lib/env';
+
+const STORAGE_KEY = 'chartdb_mock_diagrams';
+const useMock = API_BASE_URL === '';
+
+const saveDiagram = async (diagram: Diagram): Promise<void> => {
+    if (useMock) {
+        const diagrams: Record<string, Diagram> = JSON.parse(
+            localStorage.getItem(STORAGE_KEY) || '{}'
+        );
+        diagrams[diagram.id] = diagram;
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(diagrams));
+        return;
+    }
+
+    await fetch(`${API_BASE_URL}/diagrams/${diagram.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(diagram),
+    });
+};
+
+const getDiagram = async (id: string): Promise<Diagram | undefined> => {
+    if (useMock) {
+        const diagrams: Record<string, Diagram> = JSON.parse(
+            localStorage.getItem(STORAGE_KEY) || '{}'
+        );
+        const data = diagrams[id];
+        if (!data) {
+            return undefined;
+        }
+        return diagramSchema.parse({
+            ...data,
+            createdAt: new Date(data.createdAt),
+            updatedAt: new Date(data.updatedAt),
+        });
+    }
+
+    const response = await fetch(`${API_BASE_URL}/diagrams/${id}`);
+    if (!response.ok) {
+        return undefined;
+    }
+    const data = await response.json();
+    return diagramSchema.parse({
+        ...data,
+        createdAt: new Date(data.createdAt),
+        updatedAt: new Date(data.updatedAt),
+    });
+};
+
+export { saveDiagram, getDiagram };

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -12,3 +12,5 @@ export const HIDE_CHARTDB_CLOUD: boolean =
 export const DISABLE_ANALYTICS: boolean =
     (window?.env?.DISABLE_ANALYTICS ??
         import.meta.env.VITE_DISABLE_ANALYTICS) === 'true';
+
+export const API_BASE_URL: string = import.meta.env.VITE_API_BASE_URL ?? '';


### PR DESCRIPTION
## Summary
- add `API_BASE_URL` setting
- provide API calls with a local storage mock
- expose API persistence methods via StorageContext
- document remote diagram storage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/compat')*
- `npm run build` *(fails: Cannot find package '@eslint/compat')*

------
https://chatgpt.com/codex/tasks/task_b_686b74f214f4832baf19e345ea82c026